### PR TITLE
Update to the conversion from WARC to WAT in the README.MD file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ git clone https://github.com/commoncrawl/ia-hadoop-tools
 cd ia-hadoop-tools
 mvn package
 ```
+If the build of ia-hadoop-tools fails, you can clone this fork instead.
+
+```
+git clone https://github.com/AmrSheta22/ia-hadoop-tools.git
+cd ia-hadoop-tools
+mvn package -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2
+```
+
 Note that the WARC file must be placed in a folder warc/
 
 Run the following to generate wat.gz from some file.warc.gz or arc.gz:

--- a/README.md
+++ b/README.md
@@ -19,24 +19,28 @@ See:
 
 https://github.com/webrecorder/warcio/issues/102
 
-Use instead webarchive-commons:
+Use instead ia-web-commons and ia-hadoop-tools[]:
 
-https://github.com/iipc/webarchive-commons
+https://github.com/commoncrawl/ia-web-commons
 
 Assuming Java and Maven are there, build webarchive-commons as follows:
 
 ```
-git clone https://github.com/iipc/webarchive-commons.git
-cd webarchive-commons/
-mvn clean install
+git clone https://github.com/commoncrawl/ia-web-commons
+cd ia-web-commons
+mvn -f pom.xml install
+cd -
+git clone https://github.com/commoncrawl/ia-hadoop-tools
+cd ia-hadoop-tools
+mvn package
 ```
-
-Then look under the `target/` subdirectory for the JAR file.
+Note that the WARC file must be placed in a folder warc/
 
 Run the following to generate wat.gz from some file.warc.gz or arc.gz:
 
 ```
-java -cp target/webarchive-commons-jar-with-dependencies.jar org.archive.extract.ResourceExtractor -wat file.warc.gz > file.wat.gz
+java -jar ./target/ia-hadoop-tools-jar-with-dependencies.jar WEATGenerator \
+name_of_archive .../warc/warcfile.warc.gz
 ```
 
 Use a tool such as Ansible, dsh, or pdsh (among many others) for ad-hoc


### PR DESCRIPTION
The webarchive commons repo doesn't work for converting from WARC to WAT anymore (I think). There is a possibility that I just didn't understand the wording of how to use it but this was a problem for me multiple times.
Additionally, A link doesn't work in the original in ia-hadoop-tools, so I changed it and updated it in my fork. I submitted a pull request to the original repo but this is a modification until the pull request gets accepted.